### PR TITLE
Minor changes to improve startup robustness

### DIFF
--- a/WPFSharp.Globalizer/GlobalizationManager.cs
+++ b/WPFSharp.Globalizer/GlobalizationManager.cs
@@ -37,11 +37,16 @@ namespace WPFSharp.Globalizer
             if (CultureInfo.CurrentCulture.Name.Equals(inFiveCharLang) && !inForceSwitch)
                 return;
 
+            if(!AvailableLanguages.Instance.Contains(inFiveCharLang))
+            {
+                throw new CultureNotFoundException(String.Format("The language {0} is not available.", inFiveCharLang));
+            }
+
             // Set the new language
             var ci = new CultureInfo(inFiveCharLang);
             Thread.CurrentThread.CurrentCulture = ci;
             Thread.CurrentThread.CurrentUICulture = ci;
-
+            
             string[] xamlFiles = Directory.GetFiles(Path.Combine(DefaultPath, inFiveCharLang), "*.xaml");
 
             // If there are no files, do nothing
@@ -135,10 +140,20 @@ namespace WPFSharp.Globalizer
                 {
                     var path = Path.Combine(Path.GetDirectoryName(globalizationResourceDictionary.Source), styleFile);
                     // Todo: Check for file and if not there, look in the Styles dir
-                    MergedDictionaries.Add(LoadFromFile(path, false));
+
+                    var tempStyleDict = LoadFromFile(path, false);
+                    if (tempStyleDict != null)
+                    {
+                        MergedDictionaries.Add(tempStyleDict);
+                    }
                     return;
                 }
-                MergedDictionaries.Add(LoadFromFile(styleFile, false));
+
+                var styleDict = LoadFromFile(styleFile, false);
+                if (styleDict != null)
+                {
+                    MergedDictionaries.Add(styleDict);
+                }
             }
         }
 

--- a/WPFSharp.Globalizer/GlobalizedApplication.cs
+++ b/WPFSharp.Globalizer/GlobalizedApplication.cs
@@ -1,5 +1,6 @@
 ﻿// See license at bottom of file
 using System;
+using System.Globalization;
 using System.IO;
 using System.Threading;
 using System.Windows;
@@ -18,6 +19,11 @@ namespace WPFSharp.Globalizer
         {
             // Make App a singleton
             Instance = this;
+            
+        }
+
+        protected override void OnStartup(StartupEventArgs e)
+        {
             Init();
         }
 
@@ -43,7 +49,15 @@ namespace WPFSharp.Globalizer
 
             // Get current 5 character language and load the appropriate Globalization file
             CreateAvailableLanguages();
-            GlobalizationManager.SwitchLanguage(Thread.CurrentThread.CurrentCulture.Name, true);
+            try
+            {
+                GlobalizationManager.SwitchLanguage(Thread.CurrentThread.CurrentCulture.Name, true);
+            }
+            catch(CultureNotFoundException)
+            {
+                // Try the fallback
+                GlobalizationManager.SwitchLanguage("en-US", true);
+            }
 
             // Create the FallbackResourceDictionary
             FallbackResourceDictionary = new FallbackResourceDictionary() { Name = "Fallback" };


### PR DESCRIPTION
Use the AvailableLanguages collection during initialization to determine if we have a language before trying to set it (and failing miserably)
If we fail to load a file, don't try to add null values to the internal collections.

These changes were prompted by some mystifying failures occurring on customer machines with non-US locale settings.  Because initialization occurred in the app constructor prior to my user code being able to run, the unhandled exception handler did not get tripped and could not produce a useful crash log.  I have moved the initialization to the OnStartup handler, which appears to be early enough for the localization to proceed correctly.