### PR TITLE
Modified ResourceDictionaryManagerBase.cs to allow the use of regular…

### DIFF
--- a/Examples/WPFSharp.Globalizer.MVVMExample/App.xaml
+++ b/Examples/WPFSharp.Globalizer.MVVMExample/App.xaml
@@ -4,6 +4,10 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:Global="clr-namespace:WPFSharp.Globalizer;assembly=WPFSharp.Globalizer">
     <Application.Resources>
-
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary x:Name="TestIcons" Source="Graphics/Icons.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </Application.Resources>
 </Global:GlobalizedApplication >

--- a/Examples/WPFSharp.Globalizer.MVVMExample/Graphics/Icons.xaml
+++ b/Examples/WPFSharp.Globalizer.MVVMExample/Graphics/Icons.xaml
@@ -1,0 +1,8 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Canvas x:Key="icon_x" Width="76" Height="76" Clip="F1 M 0,0L 76,0L 76,76L 0,76L 0,0">
+        <Path Width="31.6666" Height="31.6667" Canvas.Left="22.1666" Canvas.Top="22.1667" Stretch="Fill" Fill="#FF000000" Data="F1 M 26.9166,22.1667L 37.9999,33.25L 49.0832,22.1668L 53.8332,26.9168L 42.7499,38L 53.8332,49.0834L 49.0833,53.8334L 37.9999,42.75L 26.9166,53.8334L 22.1666,49.0833L 33.25,38L 22.1667,26.9167L 26.9166,22.1667 Z "/>
+    </Canvas>
+
+</ResourceDictionary>

--- a/Examples/WPFSharp.Globalizer.MVVMExample/View/PersonView.xaml
+++ b/Examples/WPFSharp.Globalizer.MVVMExample/View/PersonView.xaml
@@ -45,6 +45,13 @@
         <TextBox Name="FirstNameTextBox" Grid.Column="2" Grid.Row="3" Text="{Binding FirstNameValue}" />
         <TextBox Name="LastNameTextBox" Grid.Column="2" Grid.Row="4" Text="{Binding LastNameValue}"/>
         <TextBox Name="AgeTextBox" Grid.Column="2" Grid.Row="5" Text="{Binding AgeValue}"/>
-        <Button Content="{globalizer:GlobalizedResource Form_Button_Clear, FallbackValue=Clear}" Grid.Column="2" Grid.Row="6" HorizontalAlignment="Right" Name="ButtonClear" Width="75" MinHeight="20" Click="button1_Click" />
+        <Button Grid.Column="2" Grid.Row="6" HorizontalAlignment="Right" Name="ButtonClear" Width="75" MinHeight="20" Click="button1_Click">
+            <StackPanel Orientation="Horizontal">
+                <Viewbox Height="15" VerticalAlignment="Center">
+                    <ContentControl Content="{StaticResource icon_x}"></ContentControl>
+                </Viewbox>
+                <ContentControl Content="{globalizer:GlobalizedResource Form_Button_Clear, FallbackValue=Clear}"></ContentControl>
+            </StackPanel>
+        </Button>
     </Grid>
 </UserControl>

--- a/Examples/WPFSharp.Globalizer.MVVMExample/WPFSharp.Globalizer.MVVMExample.csproj
+++ b/Examples/WPFSharp.Globalizer.MVVMExample/WPFSharp.Globalizer.MVVMExample.csproj
@@ -140,6 +140,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Resource Include="README.txt" />
+    <Page Include="Graphics\Icons.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Properties\DesignTimeResources.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/WPFSharp.Globalizer/ResourceDictionaryManagerBase.cs
+++ b/WPFSharp.Globalizer/ResourceDictionaryManagerBase.cs
@@ -48,10 +48,15 @@ namespace WPFSharp.Globalizer
         public void Remove(string inResourceDictionaryName)
         {
             EnhancedResourceDictionary erdToRemove = null;
-            foreach (EnhancedResourceDictionary erd in MergedDictionaries)
+
+            //enumerate through all resource dictionaries
+            foreach (ResourceDictionary rd in MergedDictionaries)
             {
-                if (erd.Name == inResourceDictionaryName)
-                    erdToRemove = erd;
+                //Only operate on globalized enahncedresourcedictionary types
+                var erd = rd as EnhancedResourceDictionary;
+                if(erd != null)
+                    if (erd.Name == inResourceDictionaryName)
+                        erdToRemove = erd;
             }
             MergedDictionaries.Remove(erdToRemove);
         }


### PR DESCRIPTION
… MergedDictionaries in application.

This seems to fix the issue:
[Use of regular merged dictionaries broken with addition of library ](https://github.com/rhyous/WPFSharp.Globalizer/issues/7)

I added a new resource dictionary in the MVVM example app that contains an icon and I reference it in PersonView. All seems to work.


